### PR TITLE
check if login succeeds, fixed an error

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,8 +32,7 @@ class SporkInstance:
             passwordField.send_keys(self.credentials.get("password"))
             passwordField.send_keys(Keys.ENTER)
             
-            #returns true if the login is no longer attached to the DOM, i.e. no longer there
-            #else makes an error
+            #wait 3 seconds for the passwordfield to stop being attached to the DOM
             staleness = WebDriverWait(self.driver, 3).until(ec.staleness_of(passwordField))
 
             #whether to continue, as it would produce an error if it tried to use webdriver and it quit

--- a/main.py
+++ b/main.py
@@ -53,6 +53,6 @@ class SporkInstance:
 
 if __name__ == "__main__":
     client = SporkInstance("chromedriver.exe", False, "creds.json")
-    success = client.enter_credentials()
-    if (success):
+    status = client.enter_credentials()
+    if status:
         client.click_join_button()

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def parse_json(json_file_path):
     with open(json_file_path, 'r') as json_file:
         dictionary = json.load(json_file)
         return dictionary
-    
+
 class SporkInstance:
     def __init__(self, driver_path, is_headless, json_creds_path= "creds.json"):
         if is_headless:
@@ -20,7 +20,6 @@ class SporkInstance:
         self.driver = webdriver.Chrome(driver_path, options=option)
         self.driver.get('https://spork.school/schedule')
         self.credentials = parse_json(json_creds_path)
-
 
     def enter_credentials(self):
         try:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,11 @@
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as ec
+from selenium.common import exceptions
+import json
+
 def parse_json(json_file_path):
     with open(json_file_path, 'r') as json_file:
         dictionary = json.load(json_file)
@@ -46,7 +54,7 @@ class SporkInstance:
             self.driver.quit()
 
 if __name__ == "__main__":
-    client = SporkInstance("path", False, "creds.json")
+    client = SporkInstance("chromedriver.exe", False, "creds.json")
     success = client.enter_credentials()
     if (success):
         client.click_join_button()

--- a/main.py
+++ b/main.py
@@ -1,18 +1,8 @@
-from selenium import webdriver
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as ec
-from selenium.common import exceptions
-
-import json
-
-
 def parse_json(json_file_path):
     with open(json_file_path, 'r') as json_file:
         dictionary = json.load(json_file)
         return dictionary
-
+    
 class SporkInstance:
     def __init__(self, driver_path, is_headless, json_creds_path= "creds.json"):
         if is_headless:
@@ -34,19 +24,29 @@ class SporkInstance:
             passwordField.clear()
             passwordField.send_keys(self.credentials.get("password"))
             passwordField.send_keys(Keys.ENTER)
+            
+            #returns true if the login is no longer attached to the DOM, i.e. no longer there
+            #else makes an error
+            staleness = WebDriverWait(self.driver, 3).until(ec.staleness_of(passwordField))
+
+            #whether to continue, as it would produce an error if it tried to use webdriver and it quit
+            return True
         except (exceptions.NoSuchElementException, exceptions.TimeoutException):
+            print("Unable to enter credentials")
             self.driver.quit()
+            return False
 
     def click_join_button(self):
         try:
             joinButtons = WebDriverWait(self.driver, 10).until(ec.presence_of_all_elements_located((By.CSS_SELECTOR, 'button.ui.green.compact.button')))
-            for i in joinButtons:
-                i.click()
+            for button in joinButtons:
+                button.click()
         except (exceptions.NoSuchElementException, exceptions.TimeoutException):
-            print("no button")
+            print("No button to press")
             self.driver.quit()
 
 if __name__ == "__main__":
-    client = SporkInstance("chromedriver.exe", False, "creds.json")
-    client.enter_credentials()
-    client.click_join_button()
+    client = SporkInstance("path", False, "creds.json")
+    success = client.enter_credentials()
+    if (success):
+        client.click_join_button()


### PR DESCRIPTION
staleness = WebDriverWait(self.driver, 3).until(ec.staleness_of(passwordField))
    - ec.staleness_of detects if the elment, namely the password, is still connected to the DOM, basically the page

success = client.enter_credentials()
   - Only clicks join button if the credentials have succeeded